### PR TITLE
add filters and call details to worker tasks in proto

### DIFF
--- a/tcnapi/exile/gate/v3/worker.proto
+++ b/tcnapi/exile/gate/v3/worker.proto
@@ -238,12 +238,14 @@ message GetRecordFieldsTask {
   string pool_id = 1;
   string record_id = 2;
   repeated string field_names = 3;
+  repeated Filter filters = 4;
 }
 
 message SetRecordFieldsTask {
   string pool_id = 1;
   string record_id = 2;
   repeated Field fields = 3;
+  repeated Filter filters = 4;
 }
 
 message CreatePaymentTask {
@@ -255,6 +257,10 @@ message CreatePaymentTask {
 message PopAccountTask {
   string pool_id = 1;
   string record_id = 2;
+  string partner_agent_id = 3;
+  int64 call_sid = 4;
+  CallType call_type = 5;
+  repeated Filter filters = 6;
 }
 
 message ExecuteLogicTask {


### PR DESCRIPTION
This pull request updates the `tcnapi/exile/gate/v3/worker.proto` file to extend the functionality of several task messages by adding new fields, primarily to support more flexible filtering and to capture additional context for account-related tasks.

**Enhancements to task message definitions:**

*Filtering support:*
- Added a `repeated Filter filters` field to both the `GetRecordFieldsTask` and `SetRecordFieldsTask` messages, allowing these tasks to specify multiple filters for more granular querying and updating of records.
- Added a `repeated Filter filters` field to the `PopAccountTask` message, enabling filtered account operations.

*Additional context for account operations:*
- Added `partner_agent_id`, `call_sid` (as `int64`), and `call_type` (as `CallType`) fields to the `PopAccountTask` message to capture more detailed context about the account operation, such as which partner agent is involved and call-specific information.Enhances GetRecordFieldsTask, SetRecordFieldsTask, and PopAccountTask to include filter capabilities and call details, allowing more precise task execution control and recording.