### PR TITLE
Add org_id to WorkItem for owner tracking

### DIFF
--- a/tcnapi/exile/gate/v3/worker.proto
+++ b/tcnapi/exile/gate/v3/worker.proto
@@ -124,6 +124,10 @@ message WorkItem {
   // Set by the gate when dispatching from an incoming gRPC call.
   string trace_parent = 5;
 
+  // Organization that owns this work item. Populated by the gate dispatcher
+  // from the job/event's owning org. JSON name is `orgId` (proto3 default).
+  string org_id = 6;
+
   oneof task {
     // Jobs (require Result)
     ListPoolsTask list_pools = 10;


### PR DESCRIPTION
This pull request introduces a small but important change to the `WorkItem` message in the `worker.proto` file. An `org_id` field has been added to track the organization that owns each work item, which will be populated by the gate dispatcher.

- API enhancement:
  * Added a new `string org_id = 6;` field to the `WorkItem` message to store the owning organization's ID, with documentation explaining its purpose and population.Include the organization ID in WorkItem to identify the owning organization, populated by the gate dispatcher.